### PR TITLE
Use an inline annotation for DI

### DIFF
--- a/src/angular-lightbox.js
+++ b/src/angular-lightbox.js
@@ -7,7 +7,7 @@
  * </ANY>
  */
 angular.module('angular-lightbox', [])
-.directive('lightbox', function($timeout) {
+.directive('lightbox', ["$timeout", function($timeout) {
   return{
     restrict: 'A',
     scope: {
@@ -157,4 +157,4 @@ angular.module('angular-lightbox', [])
       };
     }
   };
-});
+}]);


### PR DESCRIPTION
After minification the below error will be shown.
Error: $injector:unpr Unknown Provider
Unknown provider: eProvider <- e <- lightboxDirective

On minification,  all of the function arguments would be minified as well, and the dependency injector would not be able to identify services correctly. An inline annotation should be used.